### PR TITLE
Fix deadlock in TagSubprocess

### DIFF
--- a/gtags.py
+++ b/gtags.py
@@ -58,9 +58,8 @@ class TagSubprocess(object):
 
     def call(self, command, **kwargs):
         process = self.create(command, stderr=subprocess.PIPE, **kwargs)
-        retcode = process.wait()
         _, stderr = process.communicate()
-        return retcode, stderr
+        return process.returncode, stderr
 
 
 class TagFile(object):


### PR DESCRIPTION
According to Subprocess documentation Popen.wait may deadlock when
generating output and pipe buffer is filled. It was, however,
called when generating tags before communicate(), and indeed
breaking tags rebuilding when there were errors to report.

Now only communicate() is used for retrieving error data, and return
code is read from the Popen object property.

Fixes #6
