### PR TITLE
Show symbols for currently open files only

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -17,6 +17,10 @@
     "command": "gtags_show_symbols", 
     "keys": ["ctrl+t", "ctrl+s"]
   },
+  {
+    "command": "gtags_show_open_files_symbols", 
+    "keys": ["ctrl+t", "ctrl+d"]
+  },
   { // override current default
     "keys": ["ctrl+t"],
     "command": "transpose",

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -28,6 +28,9 @@
                 "command": "gtags_show_open_files_symbols"
               },
               {
+                "command": "gtags_show_current_file_symbols"
+              },
+              {
                 "command": "gtags_rebuild_tags"
               }
             ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -25,6 +25,9 @@
                 "command": "gtags_show_symbols"
               },
               {
+                "command": "gtags_show_open_files_symbols"
+              },
+              {
                 "command": "gtags_rebuild_tags"
               }
             ]

--- a/gtags.py
+++ b/gtags.py
@@ -116,6 +116,13 @@ class TagFile(object):
             print(stderr)
         return success
 
+    def open_files_symbols(self):
+        files=" ".join(['"'+x.file_name()+'"' for x in sublime.active_window().views()])
+        out=self.subprocess.stdout('global -f %s' % files)
+        if int(sublime.version()) >= 3000:
+            out = out.decode("utf-8")
+        return [line.split(" ",2)[0] for line in out.splitlines()]
+
 
 class GTagsTest(unittest.TestCase):
     def test_start_with(self):


### PR DESCRIPTION
#### Show symbols for open files only

When working in large codebases (GTAGS > 500 MB) it can take a while (5+ seconds) to show all symbols. When working on a single feature it might be useful to only show the symbols that are defined in the files that are currently open. Global has support to show the symbols for a subset of files (-f flag). I created a new command that uses this option (GtagsShowOpenFilesSymbols). Feel free to comment or improve.
