### PR TITLE
Fix some bugs at SublimeText 3 under Windows environment

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,19 @@
+[
+    {
+        "caption": "Gtags: Show symbol",
+        "command": "gtags_show_symbols",
+    },
+    {
+        "caption": "Gtags: Rebuild tags",
+        "command": "gtags_rebuild_tags",
+    },
+    {
+        "caption": "Gtags: Navigate to definition",
+        "command": "gtags_navigate_to_definition",
+    },
+    {
+        "caption": "Gtags: Find references",
+        "command": "gtags_find_references",
+    },
+
+]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,9 +1,18 @@
 [
   {
+    "keys": ["ctrl+\\"],
+      "command": "show_overlay",
+      "args":
+      {
+          "overlay": "command_palette",
+          "text": "Gtags: "
+      }
+  },
+  {
     "command": "gtags_navigate_to_definition",
     "context": [],
     "keys": ["alt+."]
-  }, 
+  },
   {
     "command": "gtags_jump_back",
     "keys": ["alt+,"]
@@ -12,9 +21,9 @@
     "command": "gtags_rebuild_tags",
     "context": [],
     "keys": ["ctrl+t", "ctrl+r"]
-  }, 
+  },
   {
-    "command": "gtags_show_symbols", 
+    "command": "gtags_show_symbols",
     "keys": ["ctrl+t", "ctrl+s"]
   },
   { // override current default

--- a/gtags.py
+++ b/gtags.py
@@ -69,7 +69,7 @@ class TagSubprocess(object):
 class TagFile(object):
     def _expand_path(self, path):
         path = os.path.expandvars(os.path.expanduser(path))
-        if IS_WINDOWS:
+        if int(sublime.version()) < 3000 and IS_WINDOWS:
             path = path.encode('utf-8')
         return path
 

--- a/gtagsplugin.py
+++ b/gtagsplugin.py
@@ -16,8 +16,9 @@ else:
     import SublimeGtags.gtags
     from SublimeGtags.gtags import TagFile, PP, find_tags_root
 
-settings = sublime.load_settings('GTags.sublime-settings')
 
+def get_settings():
+    return sublime.load_settings('GTags.sublime-settings')
 
 def run_on_cwd(dir=None):
     window = sublime.active_window()
@@ -38,7 +39,7 @@ def run_on_cwd(dir=None):
         else:
             tags_root = dir[0]
 
-        tags = TagFile(tags_root, settings.get('extra_tag_paths'))
+        tags = TagFile(tags_root, get_settings().get('extra_tag_paths'))
         func(view, tags, tags_root)
 
     return wrapper
@@ -122,7 +123,7 @@ def gtags_jump_keyword(view, keywords, root, showpanel=False):
             jump(keywords[index])
 
     if showpanel or len(keywords) > 1:
-        if settings.get('show_relative_paths'):
+        if get_settings().get('show_relative_paths'):
             convert_path = lambda path: os.path.relpath(path, root)
         else:
             convert_path = os.path.normpath


### PR DESCRIPTION
1. popen error (environment can only contain strings)
2. package settings didn't load until plugin reloaded
3. parse result from "global" fail due to windows path style (containing white spaces)
